### PR TITLE
Add TicketHub defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,19 @@ if result, err := myRbac.GetRoles(ctx, authz); err != nil {
 
 Note that all RBAC calls are guarded with an authorization check. This is to ensure that the person performing the request has the appropriate permissions to make said request.
 
+### ListUserBindingsAll
+
+This emits _all_ user bindings.
+
+```golang
+if result, err := myRbac.ListUserBindingsAll(ctx, authz); err != nil {
+    log.Fatal(err)
+}
+```
+
 ### ListUserBindings
+
+This emits user bindings for the specified users.
 
 ```golang
 users := []*rbac.User{
@@ -376,7 +388,7 @@ Here, `GetUrlVar` tells the proxy how to extract url parameters. For example, if
 | Callback | Description | Required |
 | --- | --- | --- |
 | `GetAuthz` | This is the same as the client proxy. | yes |
-| `GetUsers` | This callback is used by the `ListUserBindings` proxy. The RBAC implementation does not know how the programmer stores users. Additionally, the proxy must _page users in and out_. This callback controls that behavior. See below for more details. | yes |
+| `GetUsers` | This callback is used by the `ListUserBindings` proxy. It allows the proxy to page users (and hence user bindings) in and out. If omitted, all user bindings are emitted and pagination is ignored. See below for more details. | no |
 | `OnGetUserBinding` | Control whether `GetUserBinding` is allowed. | no |
 | `OnPutUserBinding` | Control whether `PutUserBinding` is allowed. | no |
 | `OnDeleteUserBinding` | Control whether `DeleteUserBinding` is allowed. | no |
@@ -432,6 +444,8 @@ GET /user_bindings?page=3
 ``` 
 
 Here, the input bytes to `GetUsers` is the string `"3"` from the `page=3` query parameter. The output should contain a list of users for that page and an `interface{}` that serves as the value for the `"page"` key in the response. Notice that how the users are paged is ultimately up to the programmer. It's important to note, however, that the [frontend SDK](https://github.com/StyraInc/styra-run-sdk-js) assumes the above structure so you must follow suit if you want to use it. See `rbac/v1/proxy/callbacks.go` for a concrete example that stores users in an array.
+
+If the programmer does not provide a `GetUsers` callback, the proxy will internally call `ListUserBindingsAll`, emitting _all_ user bindings and ignoring pagination.
 
 ### GetUserBinding
 

--- a/api/v1/proxy/proxy.go
+++ b/api/v1/proxy/proxy.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"net/http"
 
-	"github.com/styrainc/styra-run-sdk-go/api/v1"
+	api "github.com/styrainc/styra-run-sdk-go/api/v1"
 	"github.com/styrainc/styra-run-sdk-go/internal/utils"
 )
 
@@ -17,15 +17,15 @@ type Route struct {
 	Handler http.HandlerFunc
 }
 
-type OnModifyBatchQueryInput func(authz *v1.Authz, input interface{}) interface{}
+type OnModifyBatchQueryInput func(authz *api.Authz, input interface{}) interface{}
 
 type Callbacks struct {
-	GetAuthz                v1.GetAuthz
+	GetAuthz                api.GetAuthz
 	OnModifyBatchQueryInput OnModifyBatchQueryInput
 }
 
 type Settings struct {
-	Client    v1.Client
+	Client    api.Client
 	Callbacks *Callbacks
 }
 
@@ -59,11 +59,11 @@ func (p *proxy) BatchQuery() *Route {
 			return
 		}
 
-		queries := make([]v1.Query, 0)
+		queries := make([]api.Query, 0)
 		for _, item := range request.Items {
 			queries = append(
 				queries,
-				v1.Query{
+				api.Query{
 					Path:  item.Path,
 					Input: item.Input,
 				},
@@ -85,7 +85,7 @@ func (p *proxy) BatchQuery() *Route {
 			}
 		}
 
-		// Make the request. If an error occurs and it's an http error, forward
+		// Make the request. If an error occurs, and if it's a http error, forward
 		// the payload on from the backend with the appropriate status code.
 		if err := p.settings.Client.BatchQuery(r.Context(), queries, request.Input); err != nil {
 			utils.ForwardHttpError(w, err)

--- a/examples/v1/tickethub/defaults.go
+++ b/examples/v1/tickethub/defaults.go
@@ -1,0 +1,60 @@
+package tickethub
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	api "github.com/styrainc/styra-run-sdk-go/api/v1"
+	aproxy "github.com/styrainc/styra-run-sdk-go/api/v1/proxy"
+	rbac "github.com/styrainc/styra-run-sdk-go/rbac/v1"
+	rproxy "github.com/styrainc/styra-run-sdk-go/rbac/v1/proxy"
+)
+
+func DefaultClient(token, url string) api.Client {
+	return api.New(
+		&api.Settings{
+			Token:             token,
+			Url:               url,
+			DiscoveryStrategy: api.Simple,
+			MaxRetries:        3,
+		},
+	)
+}
+
+func DefaultClientProxy(client api.Client) aproxy.Proxy {
+	return aproxy.New(
+		&aproxy.Settings{
+			Client: client,
+			Callbacks: aproxy.DefaultCallbacks(
+				&aproxy.DefaultCallbackSettings{
+					GetAuthz: api.AuthzFromCookie(),
+				},
+			),
+		},
+	)
+}
+
+func DefaultRbac(client api.Client) rbac.Rbac {
+	return rbac.New(
+		&rbac.Settings{
+			Client: client,
+		},
+	)
+}
+
+func DefaultRbacProxy(client api.Client) rproxy.Proxy {
+	return rproxy.New(
+		&rproxy.Settings{
+			Client: client,
+			GetUrlVar: func(r *http.Request, key string) string {
+				return mux.Vars(r)[key]
+			},
+			Callbacks: rproxy.DefaultCallbacks(
+				&rproxy.DefaultCallbackSettings{
+					GetAuthz: api.AuthzFromCookie(),
+				},
+			),
+		},
+	)
+}

--- a/rbac/v1/proxy/api.go
+++ b/rbac/v1/proxy/api.go
@@ -1,17 +1,16 @@
 package proxy
 
+import (
+	rbac "github.com/styrainc/styra-run-sdk-go/rbac/v1"
+)
+
 type GetRolesResponse struct {
 	Result []string `json:"result"`
 }
 
-type ListUserBinding struct {
-	Id    string   `json:"id"`
-	Roles []string `json:"roles"`
-}
-
 type ListUserBindingsResponse struct {
-	Result []*ListUserBinding `json:"result"`
-	Page   interface{}        `json:"page"`
+	Result []*rbac.UserBinding `json:"result"`
+	Page   interface{}         `json:"page"`
 }
 
 type GetUserBindingResponse struct {

--- a/rbac/v1/proxy/callbacks.go
+++ b/rbac/v1/proxy/callbacks.go
@@ -9,6 +9,16 @@ import (
 	rbac "github.com/styrainc/styra-run-sdk-go/rbac/v1"
 )
 
+type DefaultCallbackSettings struct {
+	GetAuthz api.GetAuthz
+}
+
+func DefaultCallbacks(settings *DefaultCallbackSettings) *Callbacks {
+	return &Callbacks{
+		GetAuthz: settings.GetAuthz,
+	}
+}
+
 type ArrayCallbackSettings struct {
 	GetAuthz api.GetAuthz
 	Users    []*rbac.User

--- a/rbac/v1/rbac_test.go
+++ b/rbac/v1/rbac_test.go
@@ -56,6 +56,12 @@ func TestRbac(t *testing.T) {
 		_ = result
 	}
 
+	if result, err := myRbac.ListUserBindingsAll(ctx, authz); err != nil {
+		t.Error(err)
+	} else {
+		_ = result
+	}
+
 	if result, err := myRbac.ListUserBindings(ctx, authz, users); err != nil {
 		t.Error(err)
 	} else {


### PR DESCRIPTION
In this pull request we:

* Add default factory methods for the client, RBAC, and proxy implementations to simplify the [TicketHub](https://github.com/StyraInc/styra-tickethub-go) app.
* Modify the `ListUserBindings` proxy to emit all user bindings if no `GetUsers` callback is provided.
* Update the documentation.