### PR TITLE
Fix OnModifyBatchQueryInput

### DIFF
--- a/api/v1/proxy/callbacks.go
+++ b/api/v1/proxy/callbacks.go
@@ -17,6 +17,10 @@ func DefaultCallbacks(settings *DefaultCallbackSettings) *Callbacks {
 
 func NewOnModifyBatchQueryInput() OnModifyBatchQueryInput {
 	return func(authz *api.Authz, input interface{}) interface{} {
+		if input == nil {
+			input = make(map[string]interface{})
+		}
+
 		if values, ok := input.(map[string]interface{}); ok {
 			values["tenant"] = authz.Tenant
 			values["subject"] = authz.Subject


### PR DESCRIPTION
Fixes a bug where I wasn't adding `"tenant"` and `"subject"` in queries in the client proxy.