### PR TITLE
handle authz errors in rbac

### DIFF
--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -86,3 +86,18 @@ func IsHttpError(err error, code int) bool {
 	httpError, ok := err.(HttpError)
 	return ok && httpError.Code() == code
 }
+
+type AuthzError interface {
+	error
+}
+
+type authzError struct {
+}
+
+func NewAuthzError() error {
+	return &authzError{}
+}
+
+func (a *authzError) Error() string {
+	return "forbidden"
+}

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -92,6 +92,8 @@ func ForwardHttpError(w http.ResponseWriter, err error) {
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 			}
 		}
+	} else if _, ok := err.(AuthzError); ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
 	} else {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}

--- a/rbac/v1/rbac.go
+++ b/rbac/v1/rbac.go
@@ -2,10 +2,10 @@ package v1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	api "github.com/styrainc/styra-run-sdk-go/api/v1"
+	"github.com/styrainc/styra-run-sdk-go/internal/utils"
 )
 
 const (
@@ -16,7 +16,7 @@ const (
 )
 
 var (
-	authzError = errors.New("permission denied")
+	authzError = utils.NewAuthzError()
 )
 
 type User struct {


### PR DESCRIPTION
Fixes an issue where authz errors weren't properly detected in the rbac proxy. We were emitting 5xx's, now we emit a 403 on authz failure.