### PR TITLE
Rename authz to session

### DIFF
--- a/api/v1/proxy/defaults.go
+++ b/api/v1/proxy/defaults.go
@@ -5,8 +5,8 @@ import (
 )
 
 type DefaultSettings struct {
-	Client   api.Client
-	GetAuthz api.GetAuthz
+	Client     api.Client
+	GetSession api.GetSession
 }
 
 func Default(settings *DefaultSettings) Proxy {
@@ -15,7 +15,7 @@ func Default(settings *DefaultSettings) Proxy {
 			Client: settings.Client,
 			Callbacks: DefaultCallbacks(
 				&DefaultCallbackSettings{
-					GetAuthz: settings.GetAuthz,
+					GetSession: settings.GetSession,
 				},
 			),
 		},
@@ -23,25 +23,25 @@ func Default(settings *DefaultSettings) Proxy {
 }
 
 type DefaultCallbackSettings struct {
-	GetAuthz api.GetAuthz
+	GetSession api.GetSession
 }
 
 func DefaultCallbacks(settings *DefaultCallbackSettings) *Callbacks {
 	return &Callbacks{
-		GetAuthz:                settings.GetAuthz,
+		GetSession:              settings.GetSession,
 		OnModifyBatchQueryInput: NewOnModifyBatchQueryInput(),
 	}
 }
 
 func NewOnModifyBatchQueryInput() OnModifyBatchQueryInput {
-	return func(authz *api.Authz, input interface{}) interface{} {
+	return func(session *api.Session, input interface{}) interface{} {
 		if input == nil {
 			input = make(map[string]interface{})
 		}
 
 		if values, ok := input.(map[string]interface{}); ok {
-			values["tenant"] = authz.Tenant
-			values["subject"] = authz.Subject
+			values["tenant"] = session.Tenant
+			values["subject"] = session.Subject
 		}
 
 		return input

--- a/api/v1/proxy/proxy.go
+++ b/api/v1/proxy/proxy.go
@@ -22,10 +22,10 @@ type Route struct {
 	Handler http.HandlerFunc
 }
 
-type OnModifyBatchQueryInput func(authz *api.Authz, input interface{}) interface{}
+type OnModifyBatchQueryInput func(session *api.Session, input interface{}) interface{}
 
 type Callbacks struct {
-	GetAuthz                api.GetAuthz
+	GetSession              api.GetSession
 	OnModifyBatchQueryInput OnModifyBatchQueryInput
 }
 
@@ -78,16 +78,16 @@ func (p *proxy) BatchQuery() *Route {
 
 		// Allow the user to modify inputs.
 		if p.settings.Callbacks.OnModifyBatchQueryInput != nil {
-			authz, err := p.settings.Callbacks.GetAuthz(r)
+			session, err := p.settings.Callbacks.GetSession(r)
 			if err != nil {
 				p.authzError(w, err)
 				return
 			}
 
-			request.Input = p.settings.Callbacks.OnModifyBatchQueryInput(authz, request.Input)
+			request.Input = p.settings.Callbacks.OnModifyBatchQueryInput(session, request.Input)
 
 			for _, query := range queries {
-				query.Input = p.settings.Callbacks.OnModifyBatchQueryInput(authz, query.Input)
+				query.Input = p.settings.Callbacks.OnModifyBatchQueryInput(session, query.Input)
 			}
 		}
 

--- a/api/v1/session.go
+++ b/api/v1/session.go
@@ -10,24 +10,24 @@ var (
 	credentialsError = errors.New("could not extract credentials")
 )
 
-type Authz struct {
+type Session struct {
 	Tenant  string `json:"tenant"`
 	Subject string `json:"subject"`
 }
 
-type GetAuthz func(r *http.Request) (*Authz, error)
+type GetSession func(r *http.Request) (*Session, error)
 
-func AuthzFromValues(tenant, subject string) GetAuthz {
-	return func(r *http.Request) (*Authz, error) {
-		return &Authz{
+func SessionFromValues(tenant, subject string) GetSession {
+	return func(r *http.Request) (*Session, error) {
+		return &Session{
 			Tenant:  tenant,
 			Subject: subject,
 		}, nil
 	}
 }
 
-func AuthzFromCookie() GetAuthz {
-	return func(r *http.Request) (*Authz, error) {
+func SessionFromCookie() GetSession {
+	return func(r *http.Request) (*Session, error) {
 		cookie, err := r.Cookie("user")
 		if err != nil {
 			return nil, err
@@ -48,15 +48,15 @@ func AuthzFromCookie() GetAuthz {
 			return nil, credentialsError
 		}
 
-		return &Authz{
+		return &Session{
 			Tenant:  tenant,
 			Subject: subject,
 		}, nil
 	}
 }
 
-func AuthzFromContext() GetAuthz {
-	return func(r *http.Request) (*Authz, error) {
+func SessionFromContext() GetSession {
+	return func(r *http.Request) (*Session, error) {
 		var tenant, subject string
 
 		if value, ok := r.Context().Value("tenant").(string); ok && value != "" {
@@ -71,7 +71,7 @@ func AuthzFromContext() GetAuthz {
 			return nil, credentialsError
 		}
 
-		return &Authz{
+		return &Session{
 			Tenant:  tenant,
 			Subject: subject,
 		}, nil

--- a/examples/v1/proxies/gorilla_mux/main.go
+++ b/examples/v1/proxies/gorilla_mux/main.go
@@ -60,12 +60,12 @@ func main() {
 			Client: client,
 			ClientCallbacks: aproxy.DefaultCallbacks(
 				&aproxy.DefaultCallbackSettings{
-					GetAuthz: api.AuthzFromValues(tenant, subject),
+					GetSession: api.SessionFromValues(tenant, subject),
 				},
 			),
 			RbacCallbacks: rproxy.ArrayCallbacks(
 				&rproxy.ArrayCallbackSettings{
-					GetAuthz: api.AuthzFromValues(tenant, subject),
+					GetAuthz: api.SessionFromValues(tenant, subject),
 					Users:    users,
 					PageSize: 3,
 				},

--- a/rbac/v1/proxy/defaults.go
+++ b/rbac/v1/proxy/defaults.go
@@ -12,7 +12,7 @@ import (
 type DefaultSettings struct {
 	Client    api.Client
 	GetUrlVar GetUrlVar
-	GetAuthz  api.GetAuthz
+	GetAuthz  api.GetSession
 }
 
 func Default(settings *DefaultSettings) Proxy {
@@ -30,24 +30,24 @@ func Default(settings *DefaultSettings) Proxy {
 }
 
 type DefaultCallbackSettings struct {
-	GetAuthz api.GetAuthz
+	GetAuthz api.GetSession
 }
 
 func DefaultCallbacks(settings *DefaultCallbackSettings) *Callbacks {
 	return &Callbacks{
-		GetAuthz: settings.GetAuthz,
+		GetSession: settings.GetAuthz,
 	}
 }
 
 type ArrayCallbackSettings struct {
-	GetAuthz api.GetAuthz
+	GetAuthz api.GetSession
 	Users    []*rbac.User
 	PageSize int
 }
 
 func ArrayCallbacks(settings *ArrayCallbackSettings) *Callbacks {
 	return &Callbacks{
-		GetAuthz:            settings.GetAuthz,
+		GetSession:          settings.GetAuthz,
 		GetUsers:            NewGetUsers(settings.Users, settings.PageSize),
 		OnGetUserBinding:    NewUserExists(settings.Users),
 		OnPutUserBinding:    NewUserExists(settings.Users),

--- a/rbac/v1/rbac_test.go
+++ b/rbac/v1/rbac_test.go
@@ -45,24 +45,24 @@ func TestRbac(t *testing.T) {
 		},
 	)
 
-	authz := &api.Authz{
+	session := &api.Session{
 		Tenant:  tenant,
 		Subject: subject,
 	}
 
-	if result, err := myRbac.GetRoles(ctx, authz); err != nil {
+	if result, err := myRbac.GetRoles(ctx, session); err != nil {
 		t.Error(err)
 	} else {
 		_ = result
 	}
 
-	if result, err := myRbac.ListUserBindingsAll(ctx, authz); err != nil {
+	if result, err := myRbac.ListUserBindingsAll(ctx, session); err != nil {
 		t.Error(err)
 	} else {
 		_ = result
 	}
 
-	if result, err := myRbac.ListUserBindings(ctx, authz, users); err != nil {
+	if result, err := myRbac.ListUserBindings(ctx, session, users); err != nil {
 		t.Error(err)
 	} else {
 		_ = result
@@ -72,7 +72,7 @@ func TestRbac(t *testing.T) {
 		Id: "cesar",
 	}
 
-	if result, err := myRbac.GetUserBinding(ctx, authz, bruce); err != nil {
+	if result, err := myRbac.GetUserBinding(ctx, session, bruce); err != nil {
 		t.Error(err)
 	} else {
 		_ = result
@@ -82,11 +82,11 @@ func TestRbac(t *testing.T) {
 		Roles: []string{"OWNER"},
 	}
 
-	if err := myRbac.PutUserBinding(ctx, authz, bruce, binding); err != nil {
+	if err := myRbac.PutUserBinding(ctx, session, bruce, binding); err != nil {
 		t.Error(err)
 	}
 
-	if err := myRbac.DeleteUserBinding(ctx, authz, bruce); err != nil {
+	if err := myRbac.DeleteUserBinding(ctx, session, bruce); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
This pull requests renames instances of `Authz` to `Session` which is a bit more general. It also simplifies the `README` code snippets to not handle errors.