### PR TITLE
Add client proxy handlers

### DIFF
--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	dataPlaneUrlFormat      = "%s/data/%s"
-	dataPlaneBatchUrlFormat = "%s/data_batch"
-	batchLimit              = 20
+	dataPlanePath      = "/data"
+	dataPlaneBatchPath = "/data_batch"
+	batchLimit         = 20
 )
 
 type DiscoveryStrategy uint
@@ -88,8 +88,13 @@ func (c *client) getData(ctx context.Context, url, path string, result interface
 		Result: result,
 	}
 
+	url, err := utils.JoinPath(url, dataPlanePath, path)
+	if err != nil {
+		return err
+	}
+
 	rest := &utils.Rest{
-		Url:     fmt.Sprintf(dataPlaneUrlFormat, url, path),
+		Url:     url,
 		Method:  http.MethodGet,
 		Client:  c.settings.Client,
 		Headers: c.bearer(),
@@ -112,8 +117,13 @@ func (c *client) PutData(ctx context.Context, path string, data interface{}) err
 }
 
 func (c *client) putData(ctx context.Context, url, path string, data interface{}) error {
+	url, err := utils.JoinPath(url, dataPlanePath, path)
+	if err != nil {
+		return err
+	}
+
 	rest := &utils.Rest{
-		Url:     fmt.Sprintf(dataPlaneUrlFormat, url, path),
+		Url:     url,
 		Method:  http.MethodPut,
 		Client:  c.settings.Client,
 		Headers: c.bearerAndJson(),
@@ -137,8 +147,13 @@ func (c *client) DeleteData(ctx context.Context, path string) error {
 }
 
 func (c *client) deleteData(ctx context.Context, url, path string) error {
+	url, err := utils.JoinPath(url, dataPlanePath, path)
+	if err != nil {
+		return err
+	}
+
 	rest := &utils.Rest{
-		Url:     fmt.Sprintf(dataPlaneUrlFormat, url, path),
+		Url:     url,
 		Method:  http.MethodDelete,
 		Client:  c.settings.Client,
 		Headers: c.bearer(),
@@ -172,8 +187,13 @@ func (c *client) query(ctx context.Context, url, path string, input, result inte
 		Result: result,
 	}
 
+	url, err := utils.JoinPath(url, dataPlanePath, path)
+	if err != nil {
+		return err
+	}
+
 	rest := &utils.Rest{
-		Url:     fmt.Sprintf(dataPlaneUrlFormat, url, path),
+		Url:     url,
 		Method:  http.MethodPost,
 		Client:  c.settings.Client,
 		Headers: c.bearerAndJson(),
@@ -262,8 +282,13 @@ func (c *client) doBatchQuery(ctx context.Context, url string, queries []Query, 
 		} `json:"result"`
 	}{}
 
+	url, err := utils.JoinPath(url, dataPlaneBatchPath)
+	if err != nil {
+		return err
+	}
+
 	rest := &utils.Rest{
-		Url:     fmt.Sprintf(dataPlaneBatchUrlFormat, url),
+		Url:     url,
 		Method:  http.MethodPost,
 		Client:  c.settings.Client,
 		Headers: c.bearerAndJson(),
@@ -292,6 +317,6 @@ func (c *client) bearer() map[string]string {
 func (c *client) bearerAndJson() map[string]string {
 	return map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", c.settings.Token),
-		"Content-Type":  "application/json",
+		"Content-Type":  utils.ApplicationJson,
 	}
 }

--- a/api/v1/proxy/api.go
+++ b/api/v1/proxy/api.go
@@ -1,5 +1,29 @@
 package proxy
 
+type GetDataResponse struct {
+	Result interface{} `json:"result"`
+}
+
+type PutDataResponse struct{}
+
+type DeleteDataResponse struct{}
+
+type QueryRequest struct {
+	Input interface{} `json:"input"`
+}
+
+type QueryResponse struct {
+	Result interface{} `json:"result"`
+}
+
+type CheckRequest struct {
+	Input interface{} `json:"input"`
+}
+
+type CheckResponse struct {
+	Result bool `json:"result"`
+}
+
 type BatchProxyQuery struct {
 	Path  string      `json:"path"`
 	Input interface{} `json:"input,omitempty"`

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -5,7 +5,26 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 )
+
+const (
+	ApplicationJson = "application/json"
+)
+
+func JoinPath(base string, paths ...string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	for _, p := range paths {
+		u.Path = path.Join(u.Path, p)
+	}
+
+	return u.String(), nil
+}
 
 func HasMethod(w http.ResponseWriter, r *http.Request, method string) bool {
 	if r.Method != method {
@@ -69,7 +88,7 @@ func WriteResponse(w http.ResponseWriter, response interface{}) bool {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return false
 	} else {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", ApplicationJson)
 
 		if _, err := w.Write(bytes); err != nil {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -85,7 +104,7 @@ func ForwardHttpError(w http.ResponseWriter, err error) {
 		if bytes, err := json.Marshal(httpError.Details()); err != nil {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		} else {
-			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", ApplicationJson)
 			w.WriteHeader(httpError.Code())
 
 			if _, err := w.Write(bytes); err != nil {

--- a/rbac/v1/proxy/defaults.go
+++ b/rbac/v1/proxy/defaults.go
@@ -11,15 +11,13 @@ import (
 
 type DefaultSettings struct {
 	Client     api.Client
-	GetUrlVar  GetUrlVar
 	GetSession api.GetSession
 }
 
 func Default(settings *DefaultSettings) Proxy {
 	return New(
 		&Settings{
-			Client:    settings.Client,
-			GetUrlVar: settings.GetUrlVar,
+			Client: settings.Client,
 			Callbacks: DefaultCallbacks(
 				&DefaultCallbackSettings{
 					GetSession: settings.GetSession,

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,10 @@
+package types
+
+import "net/http"
+
+type Route struct {
+	Method  string
+	Handler http.HandlerFunc
+}
+
+type GetVar func(r *http.Request) string


### PR DESCRIPTION
This pull request adds proxy handlers for all SDK client functions. Some things of note:

* _Proxies no longer define their own routes._ This is inflexible and should be defined by the user. At present, each handler function takes arguments that define the information that it requires. For example, for the client's `GetData` handler, this is the path to said data in Styra Run. How the user structures their own HTTP handler route is entirely up to them.
* I think that each HTTP handler function should probably define a `struct` containing the predicates that it requires. For example, the `GetUser` callback is specific to listing user bindings and not necessary in other contexts. Some handlers (aka, `GetData`) take a single parameter and perhaps that's okay, but I think `struct`'s might be a better approach.
* For these various callbacks, we should probably allow for errors and handle them accordingly.
* After writing unit tests and working on these handlers, I think that `ListUserBindings` should be split into two separate routes, `ListUserBindings`, which allows the user to manage users themselves, and `ListAllUserBindings`, which simply returns everything from Styra Run. This more clear, has better separation of concerns, and easier for testing. 

I plan to address some of these concerns in a subsequent PR.

This fixes STY-14708.