### PR TITLE
Allow OnModifyInput to emit an error

### DIFF
--- a/api/v1/proxy/batch_query/batch_query.go
+++ b/api/v1/proxy/batch_query/batch_query.go
@@ -68,10 +68,20 @@ func New(settings *Settings) *types.Route {
 				return
 			}
 
-			request.Input = settings.OnModifyInput(session, "", request.Input)
+			if input, err := settings.OnModifyInput(session, "", request.Input); err != nil {
+				utils.InternalServerError(w)
+				return
+			} else {
+				request.Input = input
+			}
 
 			for i := range queries {
-				queries[i].Input = settings.OnModifyInput(session, queries[i].Path, queries[i].Input)
+				if input, err := settings.OnModifyInput(session, queries[i].Path, queries[i].Input); err != nil {
+					utils.InternalServerError(w)
+					return
+				} else {
+					queries[i].Input = input
+				}
 			}
 		}
 

--- a/api/v1/proxy/check/check.go
+++ b/api/v1/proxy/check/check.go
@@ -49,7 +49,12 @@ func New(settings *Settings) *types.Route {
 				return
 			}
 
-			request.Input = settings.OnModifyInput(session, path, request.Input)
+			if input, err := settings.OnModifyInput(session, path, request.Input); err != nil {
+				utils.InternalServerError(w)
+				return
+			} else {
+				request.Input = input
+			}
 		}
 
 		result, err := settings.Client.Check(r.Context(), path, request.Input)

--- a/api/v1/proxy/query/query.go
+++ b/api/v1/proxy/query/query.go
@@ -49,7 +49,12 @@ func New(settings *Settings) *types.Route {
 				return
 			}
 
-			request.Input = settings.OnModifyInput(session, path, request.Input)
+			if input, err := settings.OnModifyInput(session, path, request.Input); err != nil {
+				utils.InternalServerError(w)
+				return
+			} else {
+				request.Input = input
+			}
 		}
 
 		var data interface{}

--- a/api/v1/proxy/shared/defaults.go
+++ b/api/v1/proxy/shared/defaults.go
@@ -5,7 +5,7 @@ import (
 )
 
 func DefaultOnModifyInput() OnModifyInput {
-	return func(session *api.Session, path string, input interface{}) interface{} {
+	return func(session *api.Session, path string, input interface{}) (interface{}, error) {
 		if input == nil {
 			input = make(map[string]interface{})
 		}
@@ -15,6 +15,6 @@ func DefaultOnModifyInput() OnModifyInput {
 			values["subject"] = session.Subject
 		}
 
-		return input
+		return input, nil
 	}
 }

--- a/api/v1/proxy/shared/types.go
+++ b/api/v1/proxy/shared/types.go
@@ -4,4 +4,4 @@ import (
 	api "github.com/styrainc/styra-run-sdk-go/types"
 )
 
-type OnModifyInput func(session *api.Session, path string, input interface{}) interface{}
+type OnModifyInput func(session *api.Session, path string, input interface{}) (interface{}, error)


### PR DESCRIPTION
This PR modifies the `OnModifyInput` function to also emit an `error` and handles said error appropriately.

This fixes STY-14708.